### PR TITLE
Add options to include persona and character descriptions to the chat request

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Antigravity",
-    "version": "4.1.4",
+    "version": "4.1.5",
     "homePage": "https://github.com/mattjaybe/SillyTavern-EchoChamber",
     "auto_update": true
 }

--- a/settings.html
+++ b/settings.html
@@ -186,6 +186,22 @@
                     </div>
                 </div>
 
+                <!-- Include Characters Description -->
+                <div style="padding: 10px; background: rgba(0,0,0,0.1); border-radius: 6px; margin-bottom: 10px;">
+                    <label class="checkbox_label" for="discord_include_persona"
+                        style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                        <input id="discord_include_persona" type="checkbox" class="checkbox">
+                        <span style="font-size: 0.9em;"><i class="fa-solid fa-face-smile"
+                                style="width: 16px; opacity: 0.8;"></i> Include Persona</span>
+                    </label>
+                    <label class="checkbox_label" for="discord_include_character_description"
+                        style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                        <input id="discord_include_character_description" type="checkbox" class="checkbox">
+                        <span style="font-size: 0.9em;"><i class="fa-solid fa-address-card"
+                                style="width: 16px; opacity: 0.8;"></i> Include Character(s) Description</span>
+                    </label>
+                </div>
+
                 <!-- Include Past Generated EchoChambers -->
                 <div style="padding: 10px; background: rgba(0,0,0,0.1); border-radius: 6px; margin-bottom: 10px;">
                     <label class="checkbox_label" for="discord_include_past_echo"


### PR DESCRIPTION
It kinda annoyed me that chat cant "see" the characters properly - only whats mentioned in the messages - so added an option to include the actual descriptions of persona and character(s). Works both in normal chats and group chats